### PR TITLE
Develop z

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'com.danikula:videocache:2.7.0'
     implementation 'com.github.bumptech.glide:glide:4.11.0'
-    implementation 'com.google.android.exoplayer:exoplayer:2.10.4'
+    implementation 'com.google.android.exoplayer:exoplayer:2.11.3'
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.3'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.github.wseemann:FFmpegMediaMetadataRetriever-core:1.0.15'

--- a/library/src/main/res/values/ids.xml
+++ b/library/src/main/res/values/ids.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item type="id" name="layout_bottom"/>
+    <item type="id" name="current"/>
+    <item type="id" name="bottom_seek_progress"/>
+    <item type="id" name="total"/>
+    <item type="id" name="clarity"/>
+    <item type="id" name="fullscreen"/>
+    <item type="id" name="back_tiny"/>
+    <item type="id" name="layout_top"/>
+    <item type="id" name="back"/>
+    <item type="id" name="title"/>
+    <item type="id" name="battery_time_layout"/>
+    <item type="id" name="battery_level"/>
+    <item type="id" name="video_current_time"/>
+    <item type="id" name="retry_layout"/>
+    <item type="id" name="retry_btn"/>
+    <item type="id" name="replay_text"/>
+    <item type="id" name="bottom_progress"/>
+    <item type="id" name="loading"/>
+    <item type="id" name="start_layout"/>
+    <item type="id" name="start"/>
+</resources>


### PR DESCRIPTION
修复 子类继承JzvdStd时 布局删除父类viewid,出现找不到 viewId的问题
exoplayer依赖从2.10.4版本更新到2.11.3版本 并把JZMediaExo类中创建SimpleExoPlayer 的@deprecated api调用替换成最新的api调用