### PR TITLE
修复抖音列表顶部标题、底部控制栏异常显示，及ViewPagerLayoutManager空指针问题

### DIFF
--- a/demo/src/main/java/cn/jzvd/demo/CustomJzvd/JzvdStdTikTok.java
+++ b/demo/src/main/java/cn/jzvd/demo/CustomJzvd/JzvdStdTikTok.java
@@ -39,8 +39,8 @@ public class JzvdStdTikTok extends JzvdStd {
     @Override
     public void setAllControlsVisiblity(int topCon, int bottomCon, int startBtn, int loadingPro,
                                         int posterImg, int bottomPro, int retryLayout) {
-        topContainer.setVisibility(topCon);
-        bottomContainer.setVisibility(bottomCon);
+        topContainer.setVisibility(GONE);
+        bottomContainer.setVisibility(GONE);
         startButton.setVisibility(startBtn);
         loadingProgressBar.setVisibility(loadingPro);
         posterImageView.setVisibility(posterImg);

--- a/demo/src/main/java/cn/jzvd/demo/Tab_3_List/ListView/tiktok/ViewPagerLayoutManager.java
+++ b/demo/src/main/java/cn/jzvd/demo/Tab_3_List/ListView/tiktok/ViewPagerLayoutManager.java
@@ -81,7 +81,6 @@ public class ViewPagerLayoutManager extends LinearLayoutManager {
         switch (state) {
             case RecyclerView.SCROLL_STATE_IDLE:
                 View viewIdle = mPagerSnapHelper.findSnapView(this);
-                viewIdle = null;
                 if (viewIdle != null) {
                     int positionIdle = getPosition(viewIdle);
                     if (mOnViewPagerListener != null && getChildCount() == 1) {

--- a/demo/src/main/java/cn/jzvd/demo/Tab_3_List/ListView/tiktok/ViewPagerLayoutManager.java
+++ b/demo/src/main/java/cn/jzvd/demo/Tab_3_List/ListView/tiktok/ViewPagerLayoutManager.java
@@ -66,7 +66,6 @@ public class ViewPagerLayoutManager extends LinearLayoutManager {
     @Override
     public void onLayoutChildren(RecyclerView.Recycler recycler, RecyclerView.State state) {
         super.onLayoutChildren(recycler, state);
-//
     }
 
     /**
@@ -82,20 +81,14 @@ public class ViewPagerLayoutManager extends LinearLayoutManager {
         switch (state) {
             case RecyclerView.SCROLL_STATE_IDLE:
                 View viewIdle = mPagerSnapHelper.findSnapView(this);
-                int positionIdle = getPosition(viewIdle);
-                if (mOnViewPagerListener != null && getChildCount() == 1) {
-                    mOnViewPagerListener.onPageSelected(positionIdle, positionIdle == getItemCount() - 1);
+                viewIdle = null;
+                if (viewIdle != null) {
+                    int positionIdle = getPosition(viewIdle);
+                    if (mOnViewPagerListener != null && getChildCount() == 1) {
+                        mOnViewPagerListener.onPageSelected(positionIdle, positionIdle == getItemCount() - 1);
+                    }
                 }
                 break;
-            case RecyclerView.SCROLL_STATE_DRAGGING:
-                View viewDrag = mPagerSnapHelper.findSnapView(this);
-                int positionDrag = getPosition(viewDrag);
-                break;
-            case RecyclerView.SCROLL_STATE_SETTLING:
-                View viewSettling = mPagerSnapHelper.findSnapView(this);
-                int positionSettling = getPosition(viewSettling);
-                break;
-
         }
     }
 


### PR DESCRIPTION
修复抖音列表顶部标题、底部控制栏异常显示，及ViewPagerLayoutManager空指针问题